### PR TITLE
Bounce version to 0.2.12 and fix the failure caused by missing pyjwt

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sagemaker-jupyterlab-extension-common" %}
-{% set version = "0.2.10" %}
+{% set version = "0.2.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: d5968f65f59ac569bc61830eb7ef2adc4d03ef742f17857f3ec0f6068eec9488
+  sha256: 4bac9235f4a5a78e14fe5ca4fe1561e66ffbb372745ff56371c19a74dafb9081
 
 build:
   noarch: python
@@ -34,6 +34,7 @@ requirements:
     - ypy-websocket >=0.12.0
     - nbformat >=5.9.2
     - pydantic >=1.10.17,<3
+    - pyjwt >=2.10.0,<3
 
 test:
   imports:
@@ -59,3 +60,4 @@ extra:
     - chaonengquan
     - bhadrip
     - zuoyuanh
+    - edwardps


### PR DESCRIPTION
**Description**
1. Bounce version to 0.2.12 and fix the failure caused by missing pyjwt
2. Add sunp as maintainer

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [] Bumped the build number (if the version is unchanged)
* [] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

